### PR TITLE
Append .js extension if none is provided

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -45,6 +45,7 @@ function run (src) {
 }
 
 function fetch (file, cb) {
+    if(file.indexOf('.') < 0) file += '.js'
     if (sources[file]) return cb(sources[file]);
     sources[file] = {};
     var opts = { path : file };


### PR DESCRIPTION
Allows the same syntax as used in a browserify build.

I did not generate a new `wreq.js` or `wreq.min.js` because the build file did not work for me. Is there a trick to running it besides `sh bin/build.sh`?